### PR TITLE
lesson_1_8

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,17 +15,87 @@ function App() {
   const [toDoList, setToDoList] = useState([])
   const [isLoading, setIsLoading] = useState(true)
 
-  //async immitation with delay
-  useEffect( () => {
-    const promise1 = new Promise ((resolve, reject) => {
-      setTimeout( () => {
-        resolve({data:{toDoList: storageData}
-        })
-      }, 2000)
-    }).then((result) => {
-      setToDoList(result.data.toDoList)
+  const URL = `https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}`
+
+  async function readData() {
+   
+    const options = {
+      method: "GET",
+      headers: { Authorization:`Bearer ${import.meta.env.VITE_AIRTABLE_API_TOKEN}`}
+    }
+    try {
+      const response = await fetch(URL, options)
+
+      if (!response.ok) {
+        const message = `Error: ${response.status}`
+        throw new Error(message)
+      }
+
+      const receivedData = await response.json()
+
+      const todos = receivedData.records.map((e) => {
+        const newToDo = {
+          id: e.id,
+          title: e.fields.title
+        }
+        return newToDo
+      })
+     
+      setToDoList(todos)
       setIsLoading(false)
-    })
+
+      //return receivedData.records
+
+    } catch (error) {
+      console.log(error.status, error.message)
+    }
+
+  }
+
+
+  async function writeData(input) {
+
+        const airtableData = {fields:{title:`${input.title}`}}
+        const options = {
+          method: "POST",
+          headers: {
+            "Content-Type": 'application/json',
+            Authorization:`Bearer ${import.meta.env.VITE_AIRTABLE_API_TOKEN}`,
+          },
+          body:JSON.stringify(airtableData)       
+        }
+
+      try {
+    const dataSent = await fetch(URL, options)
+
+    if (!dataSent.ok) {
+      const message = `Error: ${dataSent.status}`
+      throw new Error(message)
+    }
+    const response = await dataSent.json()
+    return response
+      }
+      catch(error) {
+        console.log(error.status, error.message)
+      }
+  }
+  
+  useEffect( () => {
+    //async immitation with delay
+
+    // const promise1 = new Promise ((resolve, reject) => {
+    //   setTimeout( () => {
+    //     resolve({data:{toDoList: storageData}
+    //     })
+    //   }, 2000)
+    // }).then((result) => {
+    //   setToDoList(result.data.toDoList)
+    //   setIsLoading(false)
+    // })
+
+   readData()
+   //.then(records => console.log(records))
+   
   }, [])
 
   //push data into LS
@@ -38,6 +108,7 @@ function App() {
 
   // add func
   function addToDo(newToDo) {
+    writeData(newToDo)
     setToDoList([...toDoList, newToDo])
   }
 


### PR DESCRIPTION
Done the optional part (POST request). Didn't get the part about changing IDs from Date.now() to Airtable's standard. 

> API-)addTodo(): success response with todo payload 
> addTodo()-)setTodoList(): {id: resp.id, title: resp.Fields.title}

Looks like we suppose to do this in the code...
But it happens automatically, because we sending data without ID, Airtable assigning this parameter, and when we readData() response already includes what we want, it pushed into toDoList through the setter and we have somewhat like this: 
![321](https://github.com/lastpwnd/react-todo/assets/149648040/7aec1f32-b73c-454b-9a77-4c1ac893cc18)

No timestamps, so the order in the list is based on IDs. Can arrange it according to createdTime, if necessary
